### PR TITLE
Update of the Appendix A

### DIFF
--- a/HighEnergyObsCoreExt.tex
+++ b/HighEnergyObsCoreExt.tex
@@ -544,6 +544,11 @@ This section summarizes the proposal for the \gls{HEA} extension of Obscore. Not
 \end{tabular}
 \end{center}
 
+
+\section{Summary}\label{sec:summary}
+
+{\bf BKH: Ian, could you start writing the final section?}
+
 \pagebreak
 \printglossaries
 

--- a/UseCases.tex
+++ b/UseCases.tex
@@ -1,48 +1,73 @@
 \subsection{Event-List Data and Responses}
 
 
-\subsubsection{Use Case --- Search for event lists surrounding Sgr A* for morphological studies}
+\subsubsection{Use Case --- Search for event lists surrounding Sgr A*, for exemple for an X-ray morphological study}
 
-{\em Identify all HEA event lists encompassing Sgr~A* for initial selection for subsequent morphological studies.  Since a large number (at least several hundred) of observations are expected to match this request and the focus is on morphological studies, only the event lists and not the event bundles are desired.\/}
+{\em Identify all \gls{HE} event lists encompassing Sgr~A* for initial selection for subsequent X-ray morphological studies.  Since the focus is on X-ray morphological studies, only the event lists and not the event bundles are desired.\/}
 
 \medskip
 \noindent Find all datasets satisfying:
 \begin{enumerate}[(i)]
-  \item Target name = ``Sgr A*'' or position inside 30 arcmin from (266.4168, $-29.0078$).
-  \item dataproduct\_type = ``event-list''.
+  \item Target name = ``Sgr A*'' or position inside 30 arcmin from (266.4168, $-29.0078$)
+  \item dataproduct\_type = ``event-list''
 \end{enumerate}
 
 \begin{verbatim}
 SELECT * FROM ivoa.obscore
-NATURAL JOIN  ivoa.obscore-hea 
+NATURAL JOIN  ivoa.obscore_he 
 WHERE
-(target_name = `Sgr A*' OR
+(target_name = 'Sgr A*' OR
 CONTAINS(POINT(s_ra, s_dec), CIRCLE, 266.4168, -29.0078, 0.5) = 1) 
-AND (dataproduct_type EQ `event-list')
+AND (dataproduct_type = 'event-list')
 \end{verbatim}
 
 
-\subsubsection{Use Case --- Search for event bundles that include Cas A for spectrophotometric evolution studies}
+\subsubsection{Use Case --- Search for event bundles that include Cas A for X-ray spectrophotometric evolution studies}
 
-{\em Identify all event bundles that include the Cas A SNR and have at least 1 million events for subsequent spectrophotometric studies of the SNR expansion.  Since only a few observations are expected to match this request and because the focus is on spectrophotometric studies, the event bundles that include the responses or the ancillary products used to make the responses are required.\/}
+{\em Identify all event bundles that include the Cas A SNR and have at least 1 million events for subsequent spectrophotometric studies of the SNR expansion. Since only a few observations are expected to match this request and because the focus is on X-ray spectrophotometric studies, the event bundles that include the responses or the ancillary products used to make the responses are required.\/}
 
 \medskip
 \noindent Find all datasets satisfying:
 \begin{enumerate}[(i)]
-  \item Target name = ``Cas A'' or position inside 10 arcmin from (350.8584, $+58.8113$).
-  \item dataproduct\_type = ``event-bundle''.
+  \item Target name = ``Cas A'' or position inside 10 arcmin from (350.8584, $+58.8113$)
+  \item dataproduct\_type = ``event-bundle''
 \end{enumerate}
 
 \begin{verbatim}
 SELECT * FROM ivoa.obscore
-NATURAL JOIN  ivoa.obscore-hea 
+NATURAL JOIN  ivoa.obscore_he 
 WHERE
-(target_name = `Cas A' OR
+(target_name = 'Cas A' OR
 CONTAINS(POINT(s_ra, s_dec), CIRCLE, 350.8584, +58.8113, 0.16667) = 1) 
-AND (dataproduct_type EQ `event-bundle')
+AND (dataproduct_type = 'event-bundle')
 AND (ev_xel >= 1000000)
 \end{verbatim}
 
+\subsubsection{Use Case --- Search for event bundles via DataLink that include Cas A for a TeV spectromorphology study}
+
+{\em Identify all event lists and their associated \glspl{IRF} that include the Cas A SNR for subsequent TeV spectromorphology studies from a VERITAS data release. Since the instrumental responses are mandatory to remove instrumetal effects, the event bundles that include the  \glspl{IRF} are required.\/}
+
+\medskip
+\noindent Find all VERITAS datasets satisfying:
+\begin{enumerate}[(i)]
+  \item Target name = ``Cas A'' or position inside 4 deg from (350.8584, $+58.8113$)
+  \item dataproduct\_type = ``event-bundle''
+  \item obs\_collection = ``VERITAS-DR1''
+  (iii) access\_format =``datalink''
+\end{enumerate}
+
+\begin{verbatim}
+SELECT * FROM ivoa.obscore
+NATURAL JOIN  ivoa.obscore_he
+WHERE
+(target_name = 'Cas A' OR
+CONTAINS(POINT(s_ra, s_dec), CIRCLE, 350.8584, +58.8113, 4.0) = 1) 
+AND (dataproduct_type = 'event-bundle')
+AND (obs_collection = 'VERITAS-DR1')
+AND (access_format = ’application/x-votable+xml;content=datalink’)
+\end{verbatim}
+
+Then, for each row of the output, we get the ``access\_url'' of the DataLink and access to the data.
 
 \subsubsection{Use Case --- Identify PSF response-functions for further analysis of previously downloaded data products}
 
@@ -51,48 +76,71 @@ AND (ev_xel >= 1000000)
 \medskip
 \noindent Find all datasets satisfying:
 \begin{enumerate}[(i)]
-  \item Position inside 3 arcmin from (83.84358, $-5.43639$).
-  \item dataproduct\_type = ``response-function''.
-  \item dataproduct\_subtype = ``psf''.
-  \item obs\_id = ``4374''.
-  \item obs\_collection = ``CSC2''.
+  \item Position inside 3 arcmin from (83.84358, $-5.43639$)
+  \item dataproduct\_type = ``response-function''
+  \item dataproduct\_subtype = ``psf''
+  \item obs\_id = ``4374''
+  \item obs\_collection = ``CSC2''
 \end{enumerate}
 
 \begin{verbatim}
 SELECT * FROM ivoa.obscore
-NATURAL JOIN  ivoa.obscore-hea 
+NATURAL JOIN  ivoa.obscore_he 
 WHERE
 (CONTAINS(POINT(s_ra, s_dec), CIRCLE, 83.84358, -5.43639, 0.033333) = 1) 
-AND (dataproduct_type EQ `response-function')
-AND (dataproduct_subtype EQ `psf')
-AND (obs_id = `4374')
-AND (obs_collection = `CSC2')
+AND (dataproduct_type = 'response-function')
+AND (dataproduct_subtype = 'psf')
+AND (obs_id = '4374')
+AND (obs_collection = 'CSC2')
 \end{verbatim}
 
 
-\subsubsection{Use Case --- Search for event lists that include a fully calibrated spectral axis for BL Lac for rapid spectrophotometric evaluation}
+\subsubsection{Use Case --- Get all the \glspl{IRF} for a given CTAO observation, for simulation purposes}
+
+{\em Simulations are frequently used to estimate the science performance for a given astrophysical use case. To realise such simulations, \glspl{IRF} are required. \/ }
+
+\medskip
+\noindent Find the CTAO dataset satisfying:
+\begin{enumerate}[(i)]
+  \item dataproduct\_type = ``aeff'' or dataproduct\_type = ``psf'' or dataproduct\_type = ``edisp'' or dataproduct\_type = ``bkgrate''
+  \item obs\_id = ``4374''
+  \item obs\_collection = ``CTAO-DR1''
+\end{enumerate}
+
+\begin{verbatim}
+SELECT * FROM ivoa.obscore
+NATURAL JOIN  ivoa.obscore_he 
+WHERE
+(dataproduct_type = 'event-list' OR dataproduct_type = 'aeff' OR dataproduct_type = 'edisp' 
+  OR dataproduct_type = 'psf' OR dataproduct_type = 'bkgrate')
+AND (obs_id = '4374')
+AND (obs_collection = 'CTAO-DR1')
+\end{verbatim}
+
+
+\subsubsection{Use Case --- Search for event lists that include a fully calibrated spectral axis for BL Lac for rapid X-ray spectrophotometric evaluation}
 
 {\em Identify all event lists that include the BL Lac, have a fully calibrated spectral axis (i.e., spectral responses have already been applied), and have at least 10,000 events.  These data will be used to prepare slides for a presentation.  Note that since calib\_status = 2 may not specify that the spectral axis is fully calibrated in physical units (HEA event lists are often considered ``calibrated'' even if the spectral axis is in pulse height units ) the calibration status of the spectral axis must be checked explicitly.\/}
 
 \medskip
 \noindent Find all datasets satisfying:
 \begin{enumerate}[(i)]
-  \item Target name = ``BL Lac'' or position inside 5 arcmin from (330.680338, $+42.27777$).
-  \item dataproduct\_type = ``event-list''.
-  \item calib\_level $\geq 2$.
-  \item em\_calib\_status = ``calibrated''.
-  \item ev\_xel $\geq 10000$.
+  \item Target name = ``BL Lac'' or position inside 5 arcmin from (330.680338, $+42.27777$)
+  \item dataproduct\_type = ``event-list''
+  \item calib\_level $\geq 2$
+  \item em\_calib\_status = ``calibrated''
+  \item ev\_xel $\geq 10000$
 \end{enumerate}
 
 \begin{verbatim}
 SELECT * FROM ivoa.obscore
-NATURAL JOIN  ivoa.obscore-hea 
+NATURAL JOIN  ivoa.obscore_he 
 WHERE
-(target_name = `BL Lac' OR
+(target_name = 'BL Lac' OR
 CONTAINS(POINT(s_ra, s_dec), CIRCLE, 330.680338, +42.27777, 0.083333) = 1) 
-AND (dataproduct_type EQ `event-list')
+AND (dataproduct_type = 'event-list')
 AND (calib_level >= 2)
-AND (em_calib_status = `calibrated')
+AND (em_calib_status = 'calibrated')
 AND (ev_xel >= 10000)
 \end{verbatim}
 
@@ -104,18 +152,18 @@ AND (ev_xel >= 10000)
 \medskip
 \noindent Find all datasets satisfying:
 \begin{enumerate}[(i)]
-  \item Target name = ``Crab'' or position inside 5 arcmin from (83.6324, $+22.0174$).
-  \item dataproduct\_type = ``event-bundle''.
-  \item calib\_level $\geq 2$.
+  \item Target name = ``Crab'' or position inside 5 arcmin from (83.6324, $+22.0174$)
+  \item dataproduct\_type = ``event-bundle''
+  \item calib\_level $\geq 2$
 \end{enumerate}
 
 \begin{verbatim}
 SELECT * FROM ivoa.obscore
-NATURAL JOIN  ivoa.obscore-hea 
+NATURAL JOIN  ivoa.obscore_he 
 WHERE
-(target_name = `Crab' OR target_name = `M1' OR
+(target_name = 'Crab' OR target_name = 'M1' OR
 CONTAINS(POINT(s_ra, s_dec), CIRCLE, 83.6324, +22.0174, 0.083333) = 1) 
-AND (dataproduct_type EQ `event-bundle')
+AND (dataproduct_type = 'event-bundle')
 AND (calib_level >= 2)
 AND (s_resolution > 100)
 AND (energy_min < 100000.0) AND (energy_max >= 1000.0)
@@ -123,9 +171,87 @@ AND (o_ucd LIKE '%phys.polarization%')
 AND (o.ucd LIKE '%pos.eq%')
 \end{verbatim}
 
+\subsubsection{Use Case ---  Search for SWGO event lists and their \glspl{IRF} for the event type `very-good' in the region of Cygnus loop for a TeV spectromorphology study}
+
+{\em Identify all event lists and their associated \glspl{IRF} of the region of Cygnus loop (3$^{\circ}$ diameter) taken with SWGO. Only data of the event type `very-good' are selected, in order to limit the amount of downloaded data.\/}
+
+\medskip
+\noindent Find all SWGO datasets satisfying:
+\begin{enumerate}[(i)]
+  \item s\_region position intersects with the source modeled by a circle of 1.5 deg around (312.775, 30.683)
+  \item dataproduct\_type = ``event-list'' or ``aeff'' or ``edisp'' or ``psf'' or ``bkgrate''
+  \item obs\_collection = ``SWGO-DR1''
+  \item event\_type = ``very-good''
+\end{enumerate}
+
+First, run the ObCore query:
+\begin{verbatim}
+SELECT * FROM ivoa.obscore
+NATURAL JOIN  ivoa.obscore_he
+WHERE (INTERSECTS(s_region, CIRCLE(312.775, 30.683, 1.5)) = 1)
+AND (dataproduct_type = 'event-list' OR dataproduct_type = 'aeff' OR dataproduct_type = 'edisp' 
+  OR dataproduct_type = 'psf' OR dataproduct_type = 'bkgrate')
+AND (obs_collection = 'SWGO-DR1')
+AND (event_type = 'very-good')
+\end{verbatim}
+
+Then, for each row of the output, we identify the nature of the data and get it from its ``access\_url''.
+
+\subsubsection{Use Case --- Search for event lists and their \glspl{IRF} of CTAO South observations at energies above 10 TeV for blind search of PeVatrons from a data release using DataLink}
+
+{\em Identify all event lists and their associated \glspl{IRF} taken by CTAO South that contains events above 10 TeV. Data taken with the Small Size Telescopes or Medium Size Telescopes can be then selected. \/}
+
+\medskip
+\noindent Find all CTAO datasets satisfying:
+\begin{enumerate}[(i)]
+  \item dataproduct\_type = ``event-list''
+  \item obs\_collection = ``CTAO-DR1''
+  \item access\_format = ``datalink''
+  \item ``CTA-S'' in instrument\_name
+  \item energy\_max >= 10e+12
+\end{enumerate}
+
+First, run the ObCore query:
+\begin{verbatim}
+SELECT * FROM ivoa.obscore
+NATURAL JOIN  ivoa.obscore_he
+(dataproduct_type = 'event-list')
+AND (obs_collection = 'CTAO-DR1')
+AND (access_format = 'application/x-votable+xml;content=datalink')
+AND (instrument_name LIKE 'CTAO-S')
+AND (ENERGYMAX GE 10e+12)
+\end{verbatim}
+The query output is a VOTable that follows the DALI specification. 
+
+\medskip
+\noindent Then, process this VOTABLE to access to the data:
+\begin{enumerate}[(i)]
+  \item for each row of the query output, get the ``obs\_id'' and the ``access\_url'' of the DataLink
+  \item get the VOTABLE associated with the ``access\_url''
+  \item for each row of the VOTABLE, get the ``content\_qualifier'' and the ``accessURL''
+  \item download the data associated to each ``accessURL''
+\end{enumerate}
+
+\begin{verbatim}
+FOR EACH ROW OF OUTPUT_VOTABLE:
+  OBS_ID = OUTPUT_VOTABLE['ID']                    # To Be Checked - Mathieu, Mireille?
+  DATALINK_TABLE = GET OUTPUT_VOTABLE['access_url'] # To Be Checked - Mathieu, Mireille?
+  FOR EACH ROW OF DATALINK_TABLE:
+    - IF ROW['content_qualifier'] = 'aeff'
+    	AEFF_FILE['OBS_ID'] = GET RAW['accessURL']     # To Be Checked - Mathieu, Mireille?
+    - IF ROW['content_qualifier'] = 'edisp'
+    	EDISP_FILE['OBS_ID'] = GET RAW['accessURL']    # To Be Checked - Mathieu, Mireille?
+    - IF ROW['content_qualifier'] = 'psf'
+    	PSF_FILE['OBS_ID'] = GET RAW['accessURL']      # To Be Checked - Mathieu, Mireille?
+    - IF ROW['content_qualifier'] = 'bkgrate'
+    	BKGRATE_FILE['OBS_ID'] = GET RAW['accessURL']  # To Be Checked - Mathieu, Mireille?
+    - IF ROW['content_qualifier'] = 'event-list'
+    	EVENT_FILE['OBS_ID'] = GET RAW['accessURL']    # To Be Checked - Mathieu, Mireille?
+\end{verbatim}
 
 
-\subsection{High-Level Data Products}
+
+\subsection{Very-High-Level Data Products}
 
 \subsubsection{Use Case --- Search for Chandra Source Catalog position error MCMC draws for X-ray detections in the vicinity of Gaia DR3 486718823701242368}
 
@@ -134,46 +260,103 @@ AND (o.ucd LIKE '%pos.eq%')
 \medskip
 \noindent Find all datasets satisfying:
 \begin{enumerate}[(i)]
-  \item Position within 5.0 arcsec from (54.036061, $+61.907633$).
-  \item dataproduct\_type = ``draws''.
-  \item dataproduct\_subtype = ``poserr''.
-  \item obs\_collection = ``CSC2''.
+  \item Position within 5.0 arcsec from (54.036061, $+61.907633$)
+  \item dataproduct\_type = ``draws''
+  \item dataproduct\_subtype = ``poserr''
+  \item obs\_collection = ``CSC2''
 \end{enumerate}
 
 \begin{verbatim}
 SELECT * FROM ivoa.obscore
-NATURAL JOIN  ivoa.obscore-hea 
+NATURAL JOIN  ivoa.obscore_he 
 WHERE
 (CONTAINS(POINT(s_ra, s_dec), CIRCLE, 54.036061, +61.907633, 0.0013888) = 1) 
-AND (dataproduct_type EQ `draws')
-AND (dataproduct_subtype EQ `poserr')
-AND (obs_collection = `CSC2')
+AND (dataproduct_type = 'draws')
+AND (dataproduct_subtype = 'poserr')
+AND (obs_collection = 'CSC2')
+\end{verbatim}
+
+
+\subsubsection{Use Case --- Search for flux maps for CTAO-North observations between two observations ID}
+
+{\em Identify all flux maps from the observation of CTAO-North between selected observation identifiers selected by the user .\/}
+
+\medskip
+\noindent Find all datasets satisfying:
+\begin{enumerate}[(i)]
+  \item dataproduct\_type = ``image''
+  \item dataproduct\_subtype = ``flux-map''
+  \item obs\_collection = ``CTAO-DR1''
+  \item int(obs\_id) >= 4374
+  \item int(obs\_id) <= 4379
+  \item ``CTA-N'' in instrument\_name
+\end{enumerate}
+
+\begin{verbatim}
+SELECT * FROM ivoa.obscore
+NATURAL JOIN  ivoa.obscore_he 
+WHERE
+(dataproduct_type = 'image')
+AND (dataproduct_subtype = 'flux-map')
+AND (obs_collection = 'CTAO-HL-DR1')
+AND (instrument_name LIKE 'CTAO-N')
+AND (CAST(obs\_id AS INTEGER) > 4374)
+AND (CAST(obs\_id AS INTEGER) <= 4379)
 \end{verbatim}
 
 
 \subsubsection{Use Case --- Search for M31 source light curves and aperture photometry probability density functions that intersect a specific time interval}
 
-{\em Identify all light curves and aperture photometry probability density functions of sources detected in the field of M31 covering the energy range 0.3--7.0 keV that include observation data in the interval MJD 56320--56325 TT during which interval a transient event was thought to have occurred.  Because the data products are expected to include extremely sparse time axes, the t\_intervals TMOC must be used for the query.\/}
+{\em Identify all light curves and aperture photometry probability density functions of X-ray sources detected in the field of M31 covering the energy range 0.3--7.0 keV that include observation data in the interval MJD 56320--56325 TT during which interval a transient event was thought to have occurred.  Because the data products are expected to include extremely sparse time axes, the t\_intervals TMOC must be used for the query.\/}
 
 \medskip
 \noindent Find all datasets satisfying:
 \begin{enumerate}[(i)]
-  \item Position within 1.5 degrees from (10.6847, $+41.2688$).
-  \item dataproduct\_type = ``timeseries'' {\em or\/} ``pdf''.
-  \item calib\_level = 4.
-  \item energy\_min $\leq 0.3$ {\em and\/} energy\_max $\geq 7.0$.
-  \item t\_intervals TMOC intersects MJD 56320--56325 TT.
+  \item Position within 1.5 degrees from (10.6847, $+41.2688$)
+  \item dataproduct\_type = ``timeseries'' {\em or\/} ``pdf''
+  \item calib\_level = 4
+  \item energy\_min $\leq 0.3$ {\em and\/} energy\_max $\geq 7.0$
+  \item t\_intervals TMOC intersects MJD 56320--56325 TT
 \end{enumerate}
 
 
 \begin{verbatim}
 SELECT * FROM ivoa.obscore
-NATURAL JOIN  ivoa.obscore-hea 
+NATURAL JOIN  ivoa.obscore_he 
 WHERE
 (CONTAINS(POINT(s_ra, s_dec), CIRCLE, 10.6847, +41.2688, 1.5) = 1) 
-AND ((dataproduct_type EQ `timeseries') OR (dataproduct_type EQ `pdf'))
+AND ((dataproduct_type = 'timeseries') OR (dataproduct_type = 'pdf'))
 AND (calib_level = 4)
 AND (energy_min <= 300.0) AND (energy_max >= 7000.0)
 AND (INTERSECTS(TMOC(17, t_intervals), ...) = 1)
 \end{verbatim}
 % Can someone please update the last line?
+
+\subsubsection{Use Case --- Search for the CTAO flux light curves of PKS 2155-304 in 2030}
+
+{\em Identify all light curves obtained on the source PKS 2155-304 in 2030 with the CTAO observatory.\/}
+
+\medskip
+\noindent Find all datasets satisfying:
+\begin{enumerate}[(i)]
+  \item dataproduct\_type = ``image''.
+  \item dataproduct\_subtype = ``flux-map''.
+  \item obs\_collection = ``CTAO-DR1''.
+  \item tmin >= 62502 ({\em e.g.\/} 2030-01-01) 
+  \item tmax >= 62866 ({\em e.g.\/} 2030-12-31) 
+  \item target\_name = ``PKS 2155-304''
+\end{enumerate}
+
+\begin{verbatim}
+SELECT * FROM ivoa.obscore
+NATURAL JOIN  ivoa.obscore_he 
+WHERE
+(dataproduct_type = 'image')
+AND (dataproduct_type = 'timeseries')
+AND (dataproduct_subtype = 'flux')
+AND (obs_collection = 'CTAO-HL-DR1')
+AND (target_name = 'PKS 2155-304')
+AND (tmin >= 62502)
+AND (tmax <= 62866)
+\end{verbatim}
+


### PR DESCRIPTION
This PR update the list of Use Cases:
- EQ -> =
- ivoa.obscore-hea -> ivoa.obscore_he
- Add the TeV UC w and w/o DataLink, with the event_type, etc

@ Mireille and François: could you check the DataLink releated topics? 