### PR TITLE
adding DataLink table example in UseCase

### DIFF
--- a/UseCases.tex
+++ b/UseCases.tex
@@ -190,7 +190,7 @@ Mandatory FIELDS service\_def and error\_messsage are omitted because they are e
 \sptablerule
 {\tiny ivo://xxx/yyy/zzz\#ttt} & {\tiny https://xxx.yyy/zzz/ttt1.ext1} & \#this & {\footnotesize event-list}  {\tiny ivo://xxx/yyy/zzz\#ttt} & text/xml & 1000000 & event-list \cr
 \sptablerule
-{\tiny ivo://xxx/yyy/zzz\#ttt} & {\tiny https://xxx.yyy/zzz/ttt2.ext2} & \#calibration & {\footnotesize Effective AREA of event-list}  {\tiny ivo://xxx/yyy/zzz\#ttt} & text/csv & 10000 & aeff \cr
+{\tiny ivo://xxx/yyy/zzz\#ttt} & {\tiny https://xxx.yyy/zzz/ttt2.ext2} & \#calibration & {\footnotesize Effective AREA of the telescope/instrument associated with the event-list}  {\tiny ivo://xxx/yyy/zzz\#ttt} & text/csv & 10000 & aeff \cr
 \sptablerule
 {\tiny ivo://xxx/yyy/zzz\#ttt} & {\tiny https://xxx.yyy/zzz/ttt3.ext3} & \#calibration & {\footnotesize Energy dispersion of event-list}  {\tiny ivo://xxx/yyy/zzz\#ttt} & text/csv & 10000 & edisp \cr
 \sptablerule

--- a/UseCases.tex
+++ b/UseCases.tex
@@ -86,7 +86,7 @@ Then, for each row of the output, we identify the nature of the data product, an
   \item Target name = ``Cas A'' or position inside 2.5 arcmin from (350.8584, $+58.8113$),
   \item dataproduct\_type = ``event-bundle'',
   \item obs\_collection = ``VERITAS-DR1'',
-  \item access\_format = ``datalink''.
+  \item access\_format = ``application/fits''.
 \end{enumerate}
 
 \begin{verbatim}
@@ -97,10 +97,10 @@ WHERE
 CONTAINS(POINT(s_ra, s_dec), CIRCLE, 350.8584, +58.8113, 0.042) = 2)
 AND (dataproduct_type = 'event-bundle')
 AND (obs_collection = 'VERITAS-DR1')
-AND (access_format = ’application/x-votable+xml;content=datalink’)
+AND (access_format = ’application/fits’)
 \end{verbatim}
 
-Then, for each row of the output, we get the ``access\_url'' of the DataLink to provide access to the data.
+Then, for each row of the output, we get the ``access\_url'' of the Obscore table to provide access to the data.
 
 
 \subsubsection{Use Case --- Search for event bundles that include Cas A for X-ray spectrophotometric evolution studies}
@@ -128,12 +128,12 @@ AND (ev_xel >= 1000000)
 
 \subsubsection{Use Case --- Search for event lists and their \glspl{IRF} of CTAO South observations at energies above 10 TeV for blind search of PeVatrons from a data release using DataLink}
 
-{\em Identify all event bundles (event lists and their associated \glspl{IRF}) taken by CTAO South that contains events above 10 TeV. Data taken with the Small Size Telescopes or Medium Size Telescopes can be then selected. \/}
+{\em Identify all event lists and their associated \glspl{IRF} taken by CTAO South that contains events above 10 TeV. Data taken with the Small Size Telescopes or Medium Size Telescopes can be then selected. \/}
 
 \medskip
 \noindent Find all CTAO datasets satisfying:
 \begin{enumerate}[(i)]
-  \item dataproduct\_type = ``event-bundle'',
+  \item dataproduct\_type = ``event-list'',
   \item obs\_collection = ``CTAO-DR1'',
   \item access\_format = ``datalink'',
   \item instrument\_name contains ``CTAO-S'',
@@ -144,7 +144,7 @@ First, run the ObCore query:
 \begin{verbatim}
 SELECT * FROM ivoa.obscore
 NATURAL JOIN  ivoa.obscore_hea
-WHERE (dataproduct_type = 'event-bundle')
+WHERE (dataproduct_type = 'event-list')
 AND (obs_collection = 'CTAO-DR1')
 AND (access_format = 'application/x-votable+xml;content=datalink')
 AND (instrument_name LIKE 'CTAO-S')
@@ -179,6 +179,30 @@ FOR EACH ROW OF OUTPUT_VOTABLE:
     	EVENT_FILE['OBS_ID'] = GET RAW['accessURL']
 \end{verbatim}
 
+Table \ref{tab:datalink1} displays an example of the DataLink response table attached to such an event-list discovery. Mandatory FIELDS service\_def and error\_messsage are omitted because they are empty
+
+\begin{landscape}
+\begin{longtable}{|p{2.4cm}|p{3.3cm}|p{2.0cm}|p{2.4cm}|p{2.3cm}|p{2.4cm}|p{2.7cm}|}
+\sptablerule
+\textbf{ID}  &\textbf{\footnotesize access\_url}  &\textbf{\footnotesize semantics}&\textbf{\footnotesize description} &\textbf{\footnotesize content\_type} &\textbf{\footnotesize content\_length} &\textbf{\footnotesize content\_qualifier}\cr
+\sptablerule
+{\tiny ivo://xxx/yyy/zzz\#ttt} & {\tiny https://xxx.yyy/zzz/ttt1.ext1} & \#this & {\footnotesize event-list}  {\tiny ivo://xxx/yyy/zzz\#ttt} & text/xml & 1000000 & event-list \cr
+\sptablerule
+{\tiny ivo://xxx/yyy/zzz\#ttt} & {\tiny https://xxx.yyy/zzz/ttt2.ext2} & \#calibration & {\footnotesize Effective AREA of event-list}  {\tiny ivo://xxx/yyy/zzz\#ttt} & text/csv & 10000 & aeff \cr
+\sptablerule
+{\tiny ivo://xxx/yyy/zzz\#ttt} & {\tiny https://xxx.yyy/zzz/ttt3.ext3} & \#calibration & {\footnotesize Energy dispersion of event-list}  {\tiny ivo://xxx/yyy/zzz\#ttt} & text/csv & 10000 & edisp \cr
+\sptablerule
+{\tiny ivo://xxx/yyy/zzz\#ttt} & {\tiny https://xxx.yyy/zzz/ttt4.ext4} & \#calibration & {\footnotesize Point spread function of event-list } {\tiny ivo://xxx/yyy/zzz\#ttt} & image/fits & 50000 & psf \cr
+\sptablerule
+{\tiny ivo://xxx/yyy/zzz\#ttt} & {\tiny https://xxx.yyy/zzz/ttt5.ext5} & \#calibration & {\footnotesize Background rate of  event-list } {\tiny ivo://xxx/yyy/zzz\#ttt} & text/csv & 1000 & bkgrate \cr
+\sptablerule
+
+\caption{DataLink response table attached to an event-list  record in ObsCore.}
+
+
+\label{tab:datalink1}
+\end{longtable}
+\end{landscape}
 
 \subsubsection{Use Case --- Search for spatially resolved spectropolarimetric observations of the Crab with spectral resolution R > 100}
 

--- a/UseCases.tex
+++ b/UseCases.tex
@@ -179,7 +179,9 @@ FOR EACH ROW OF OUTPUT_VOTABLE:
     	EVENT_FILE['OBS_ID'] = GET RAW['accessURL']
 \end{verbatim}
 
-Table \ref{tab:datalink1} displays an example of the DataLink response table attached to such an event-list discovery. Mandatory FIELDS service\_def and error\_messsage are omitted because they are empty
+Table \ref{tab:datalink1} displays an example of the DataLink response table attached to such an event-list discovery. 
+The obs\_publisher\_did of the single discovered event-list is repeated in the ID column of the DataLink table.
+Mandatory FIELDS service\_def and error\_messsage are omitted because they are empty
 
 \begin{landscape}
 \begin{longtable}{|p{2.4cm}|p{3.3cm}|p{2.0cm}|p{2.4cm}|p{2.3cm}|p{2.4cm}|p{2.7cm}|}

--- a/UseCases.tex
+++ b/UseCases.tex
@@ -84,7 +84,7 @@ Then, for each row of the output, we identify the nature of the data product, an
 \noindent Find all VERITAS datasets satisfying:
 \begin{enumerate}[(i)]
   \item Target name = ``Cas A'' or position inside 2.5 arcmin from (350.8584, $+58.8113$),
-  \item dataproduct\_type = ``event-bundle'',
+  \item dataproduct\_type = ``event-list'',
   \item obs\_collection = ``VERITAS-DR1'',
   \item access\_format = ``application/fits''.
 \end{enumerate}

--- a/UseCases.tex
+++ b/UseCases.tex
@@ -86,7 +86,7 @@ Then, for each row of the output, we identify the nature of the data product, an
   \item Target name = ``Cas A'' or position inside 2.5 arcmin from (350.8584, $+58.8113$),
   \item dataproduct\_type = ``event-list'',
   \item obs\_collection = ``VERITAS-DR1'',
-  \item access\_format = ``application/fits''.
+  \item access\_format = ``datalink''.
 \end{enumerate}
 
 \begin{verbatim}

--- a/UseCases.tex
+++ b/UseCases.tex
@@ -95,7 +95,7 @@ NATURAL JOIN  ivoa.obscore_hea
 WHERE
 (target_name = 'Cas A' OR
 CONTAINS(POINT(s_ra, s_dec), CIRCLE, 350.8584, +58.8113, 0.042) = 2)
-AND (dataproduct_type = 'event-bundle')
+AND (dataproduct_type = 'event-list')
 AND (obs_collection = 'VERITAS-DR1')
 AND (access_format = ’application/x-votable+xml;content=datalink’)
 \end{verbatim}

--- a/UseCases.tex
+++ b/UseCases.tex
@@ -97,7 +97,7 @@ WHERE
 CONTAINS(POINT(s_ra, s_dec), CIRCLE, 350.8584, +58.8113, 0.042) = 2)
 AND (dataproduct_type = 'event-bundle')
 AND (obs_collection = 'VERITAS-DR1')
-AND (access_format = ’application/fits’)
+AND (access_format = ’application/x-votable+xml;content=datalink’)
 \end{verbatim}
 
 Then, for each row of the output, we get the ``access\_url'' of the Obscore table to provide access to the data.


### PR DESCRIPTION
First change is in use case 1.4 : if the exposed dataset is a bundle we don't actually need the DataLink acces mode. The access_url would benefit to be directly pointing the application/fits (whatever High energy flavor for the bundle) bundle dataset. 

Second change is in use case 1.6 : I created a dummy DataLink response table consistent with this use case. Just because the pseudo-code given in this use case may be more understandable with this table. In addition in this use case I changed event-bundle to event-list because if you expose event-bundle in ObsCore you don't need DataLink (except if you use url with fragments in the DataLink table but this another story and was not implied by the use case text)

I would like to propose other changes for use case  1.3 and 1.9 but I will first create an issue to explain that because it could be more controversial